### PR TITLE
Support for column foreign key relationship

### DIFF
--- a/src/Console/Commands/LaravelDb2DocCommand.php
+++ b/src/Console/Commands/LaravelDb2DocCommand.php
@@ -83,7 +83,6 @@ class LaravelDb2DocCommand extends Command
             $foreignKeys = collect($schema->listTableForeignKeys($table))->keyBy(function ($foreignColumn) {
                 return $foreignColumn->getLocalColumns()[0];
             });
-            
             $this->info('Table: ' . $table);
             foreach ($columns as $column) {
                 $columnName = $column->getName();
@@ -102,7 +101,6 @@ class LaravelDb2DocCommand extends Command
                 $details['default']          = (true == $column->getDefault() ? 'Yes' : 'No');
                 $details['nullable']         = (true === ! $column->getNotNull() ? 'Yes' : 'No');
                 $details['comment']          = $column->getComment();
-
                 $this->collections[$table][] = $details;
             }
         }

--- a/src/Console/Commands/LaravelDb2DocCommand.php
+++ b/src/Console/Commands/LaravelDb2DocCommand.php
@@ -79,20 +79,19 @@ class LaravelDb2DocCommand extends Command
 
         $this->collections = [];
         foreach ($tables as $table) {
-            $columns = $schema->listTableColumns($table);
+            $columns     = $schema->listTableColumns($table);
             $foreignKeys = collect($schema->listTableForeignKeys($table))->keyBy(function ($foreignColumn) {
                 return $foreignColumn->getLocalColumns()[0];
             });
             $this->info('Table: ' . $table);
             foreach ($columns as $column) {
                 $columnName = $column->getName();
-                
                 if (isset($foreignKeys[$columnName])) {
                     $foreignColumn = $foreignKeys[$columnName];
-                    $foreignTable = $foreignColumn->getForeignTableName();
-                    $columnType = 'fk -> ' . $foreignTable;
+                    $foreignTable  = $foreignColumn->getForeignTableName();
+                    $columnType    = 'fk -> ' . $foreignTable;
                 } else {
-                    $columnType = $column->getType()->getName();
+                    $columnType    = $column->getType()->getName();
                 }
                 
                 $details['column']           = $columnName;

--- a/src/Console/Commands/LaravelDb2DocCommand.php
+++ b/src/Console/Commands/LaravelDb2DocCommand.php
@@ -80,14 +80,29 @@ class LaravelDb2DocCommand extends Command
         $this->collections = [];
         foreach ($tables as $table) {
             $columns = $schema->listTableColumns($table);
+            $foreignKeys = collect($schema->listTableForeignKeys($table))->keyBy(function ($foreignColumn) {
+                return $foreignColumn->getLocalColumns()[0];
+            });
+            
             $this->info('Table: ' . $table);
             foreach ($columns as $column) {
-                $details['column']           = $column->getName();
-                $details['type']             = $column->getType()->getName();
+                $columnName = $column->getName();
+                
+                if (isset($foreignKeys[$columnName])) {
+                    $foreignColumn = $foreignKeys[$columnName];
+                    $foreignTable = $foreignColumn->getForeignTableName();
+                    $columnType = 'fk -> ' . $foreignTable;
+                } else {
+                    $columnType = $column->getType()->getName();
+                }
+                
+                $details['column']           = $columnName;
+                $details['type']             = $columnType;
                 $details['length']           = $column->getLength() && 255 !== $column->getLength() ? $column->getLength() : null;
                 $details['default']          = (true == $column->getDefault() ? 'Yes' : 'No');
                 $details['nullable']         = (true === ! $column->getNotNull() ? 'Yes' : 'No');
                 $details['comment']          = $column->getComment();
+
                 $this->collections[$table][] = $details;
             }
         }


### PR DESCRIPTION
It replaces the `type` column if foreign key's name in table schema matches the column name.

Sample result:

![image](https://user-images.githubusercontent.com/3747241/44217617-7557ca00-a1aa-11e8-9b6f-89217182a79d.png)

